### PR TITLE
add maven default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-
+.PHONY: default
+default:
+	mvn clean package
 
 field_data:
 	java -jar target/pdfparser-1.0-SNAPSHOT-jar-with-dependencies.jar \


### PR DESCRIPTION
This adds the ability to just run

```
make
```

in the root directory of this repo, which will run the `mvn clean package` command and build the `.jar` file.
